### PR TITLE
fix(config): don't require TLD in minio endpoints

### DIFF
--- a/src/config/config.schema.ts
+++ b/src/config/config.schema.ts
@@ -59,14 +59,14 @@ class ServicesConfigDatabase {
 }
 
 class ServicesConfigMinio {
-  @IsUrl()
+  @IsUrl({ require_tld: false })
   readonly endpoint: string;
 
-  @IsUrl()
+  @IsUrl({ require_tld: false })
   @IsOptional()
   readonly endpointForUser: string;
 
-  @IsUrl()
+  @IsUrl({ require_tld: false })
   @IsOptional()
   readonly endpointForJudge: string;
 


### PR DESCRIPTION
It's normal that Minio is visible from a internal host (e.g. `http://localhost:9000/` or `http://minio:9000/`). Therefore, we don't need to have to require these endpoints to have a TLD.

P.S. `require_tld` is an option from `isFQDN`, which is [sent by `isURL`](https://github.com/validatorjs/validator.js/blob/master/src/lib/isURL.js#L135).