### PR TITLE
feat: clarify log message on nil BZPOPMIN response

### DIFF
--- a/src/judge/judge-queue.service.ts
+++ b/src/judge/judge-queue.service.ts
@@ -98,7 +98,7 @@ export class JudgeQueueService {
       REDIS_CONSUME_TIMEOUT
     );
     if (!redisResponse) {
-      logger.verbose("Consuming task queue - timeout");
+      logger.verbose("Consuming task queue - timeout or empty");
       return null;
     }
 


### PR DESCRIPTION
According to [docs](https://redis.io/commands/bzpopmin), redis will return nil on timeout as well as an empty judge queue, for example, when the server is idle. In this case, the log message is flushed by timeout message, which might be misleading since redis might be actually working and it's just the judge queue that is empty.

```
api_1    | [Nest] 53   - 01/25/2021, 5:54:09 AM   Consuming task queue
api_1    | [Nest] 53   - 01/25/2021, 5:54:19 AM   Consuming task queue - timeout
api_1    | [Nest] 53   - 01/25/2021, 5:54:19 AM   Consuming task queue
api_1    | [Nest] 53   - 01/25/2021, 5:54:29 AM   Consuming task queue - timeout
api_1    | [Nest] 53   - 01/25/2021, 5:54:29 AM   Consuming task queue
api_1    | [Nest] 53   - 01/25/2021, 5:54:39 AM   Consuming task queue - timeout
```

Since it seems that we cannot easily tell from the two cases (timeout/empty queue), this PR amend to the log message and make it less confusing.